### PR TITLE
Load modules as directories (and cleaning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,8 +304,7 @@ curl -X DELETE http://localhost:7633/api/data?_user=demo \
 Make sure you use the code below to initialize the user : 
 ```javascript
 import express from "express";
-import { Engine } from 'data-primals-engine/engine';
-import { insertData, searchData } from 'data-primals-engine/modules/data';
+import {Engine, insertData, searchData } from './src/index';
 
 // Ensure the engine is initialized
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -303,7 +303,6 @@ function Layout ({header, routes, body, footer}) {
 
         return () => {
             if (eventSource) {
-                //console.log('[SSE] Fermeture de la connexion au serveur.');
                 eventSource.close();
             }
         };

--- a/client/src/DashboardView.jsx
+++ b/client/src/DashboardView.jsx
@@ -85,7 +85,6 @@ export function DashboardView({ dashboard }) {
         (newLayout) => updateDashboardLayout(dashboard, newLayout, me.username, t),
         {
             onMutate: async (newLayout) => {
-                console.log("Optimi stic update:", newLayout);
                 const previousLayout = layoutState;
                 setLayoutState(newLayout);
                 return { previousLayout };

--- a/client/src/DataTable.jsx
+++ b/client/src/DataTable.jsx
@@ -685,7 +685,6 @@ export function DataTable({
                     />
                     <ExportDialog isOpen={showExportDialog} onClose={() => {
                         setExportDialogVisible(false);
-                        console.log("close")
                     }} availableModels={models} currentModel={selectedModel.name} hasSelection={true} onExport={(data)=>{
                         exportMutation(data);
                     }} />

--- a/client/src/Field.jsx
+++ b/client/src/Field.jsx
@@ -1420,12 +1420,10 @@ export const ModelField = ({field, disableable=false, showModel=true, value, fie
     const itemsFields = [...models.find(f=>f.name === modelValue && me?.username === f._user)?.fields.map(m => ({label: m.name, value: m.name})) || []];
 
     useEffect(() => {
-        console.log({value})
         setModelValue(value)
     }, [value]);
 
     useEffect(() => {
-        console.log(modelValue)
         onChange({name: field.name, value: modelValue});
     }, [modelValue]);
 

--- a/client/src/RelationValue.jsx
+++ b/client/src/RelationValue.jsx
@@ -133,7 +133,6 @@ const RelationValue = ({ field, data, align }) => {
                 } catch (e) {
                     console.log(e);
                 }
-                //console.log(model, rel, displayValue)
                 const bgColor = // Returns a bright color in RGB
                     randomColor({
                         seed: rel._hash+rel._id,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "exports": {
     ".": "./src/index.js",
-    "./modules/*": "./src/modules/*.js",
+    "./modules/*": "./src/modules/*/index.js",
     "./client": "./client/index.js",
     "./*": "./src/*.js"
   },

--- a/src/engine.js
+++ b/src/engine.js
@@ -13,13 +13,15 @@ import {
 import http from "http";
 import cookieParser from "cookie-parser";
 import requestIp from 'request-ip';
-import {createModel, deleteModels, getModels, installAllPacks, validateModelStructure} from "./modules/data.js";
+import {createModel, deleteModels, getModels, installAllPacks, validateModelStructure} from "./modules/data/data.js";
 import {defaultModels} from "./defaultModels.js";
 import {DefaultUserProvider} from "./providers.js";
 import formidableMiddleware from 'express-formidable';
 import sirv from "sirv";
 import * as tls from "node:tls";
 import {Event} from "./events.js";
+import path from "node:path";
+import {isPathRelativeTo, isValidPath} from "./core.js";
 
 // Constants
 const isProduction = process.env.NODE_ENV === 'production'
@@ -143,18 +145,44 @@ export const Engine = {
             }
         };
 
-        await Promise.all(Config.Get('modules', []).map(async module => {
+        await Promise.all(Config.Get('modules', []).map(async moduleIdentifier => {
             try {
-                if( fs.existsSync(module) ){
-                    return await importModule(module);
-                }else {
-                    return await importModule('./modules/' + module + ".js");
+                let moduleDir;
+                const moduleName = path.basename(moduleIdentifier);
+
+                const directPath = path.resolve(moduleIdentifier);
+                let isDir = fs.existsSync(directPath) && fs.statSync(directPath).isDirectory();
+                if (isDir) {
+                    moduleDir = directPath;
+                    if (!fs.existsSync(moduleDir) || !fs.statSync(moduleDir).isDirectory()) {
+                        logger.warn(`Le dossier du module est introuvable pour l'identifiant : '${moduleIdentifier}'. Chemin cherché : '${moduleDir}'.`);
+                        return null;
+                    }
+                } else {
+                    moduleDir = path.resolve('./src/modules', moduleIdentifier);
                 }
-            } catch (e){
-                logger.info('ERROR at loading module '+ module, e.stack);
+
+                let moduleEntryPoint;
+                const jsPath = moduleDir+'.js';
+                const indexJsPath = path.join(moduleDir, 'index.js');
+                const moduleJsPath = path.join(moduleDir, `${moduleName}.js`);
+
+                if (fs.existsSync(jsPath)) {
+                    moduleEntryPoint = jsPath;
+                } else if (fs.existsSync(indexJsPath)) {
+                    moduleEntryPoint = indexJsPath;
+                } else if (fs.existsSync(moduleJsPath)) {
+                    moduleEntryPoint = moduleJsPath;
+                }
+
+                return await importModule(moduleEntryPoint);
+            } catch (e) {
+                logger.error(`Échec du chargement du module '${moduleIdentifier}':`, e.stack);
+                return null;
             }
-        })).then(async e => {
-            engine._modules = e;
+        })).then(async results => {
+            // On filtre les modules qui n'ont pas pu être chargés
+            engine._modules = results.filter(Boolean);
             return Promise.resolve();
         });
 
@@ -239,4 +267,3 @@ export const Engine = {
         return engine;
     }
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,6 @@ export { UserProvider } from './providers.js';
 
 // --- Database & Data Modules ---
 export { datasCollection, filesCollection, modelsCollection, packsCollection } from './modules/mongodb.js';
-export { searchData, insertData, editData, exportData, importData, scheduleAlerts, cancelAlerts, validateModelStructure, installPack, jobDumpUserData, loadFromDump, dumpUserData, validateRestoreRequest, patchData, deleteData, createModel, editModel, deleteModels, getModel, getModels } from './modules/data.js';
+export { searchData, insertData, editData, exportData, importData, scheduleAlerts, cancelAlerts, validateModelStructure, installPack, jobDumpUserData, loadFromDump, dumpUserData, validateRestoreRequest, patchData, deleteData, createModel, editModel, deleteModels, getModel, getModels } from './modules/data/index.js';
 
 

--- a/src/middlewares/middleware-mongodb.js
+++ b/src/middlewares/middleware-mongodb.js
@@ -60,7 +60,6 @@ function _sanitize(target, options) {
 
         if( (key === 'regex' && obj.input) || key === '$regex' ){
             obj[key] = new RegExp(val, "ui");
-            console.log('regex san', obj[key]);
         }
         else if (!wl.includes(key) && regex.test(key)) {
             isSanitized = true;

--- a/src/modules/assistant.js
+++ b/src/modules/assistant.js
@@ -5,7 +5,7 @@ import { Logger } from "../gameObject.js";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
-import {searchData,  patchData, deleteData, insertData} from "./data.js";
+import {searchData,  patchData, deleteData, insertData} from "./data";
 import { getDataAsString } from "../data.js";
 import i18n from "../../src/i18n.js";
 import {generateLimiter} from "./user.js";

--- a/src/modules/bucket.js
+++ b/src/modules/bucket.js
@@ -3,7 +3,7 @@ import AWS from "aws-sdk";
 import fs from "node:fs";
 import path from "node:path";
 import {decryptValue, encryptValue} from "../data.js";
-import {loadFromDump, validateRestoreRequest} from "./data.js";
+import {loadFromDump, validateRestoreRequest} from "./data";
 import {Logger} from "../gameObject.js";
 import {middlewareAuthenticator, userInitiator} from "./user.js";
 import {awsDefaultConfig, maxBytesPerSecondThrottleData} from "../constants.js";

--- a/src/modules/data.js
+++ b/src/modules/data.js
@@ -4620,7 +4620,7 @@ export const searchData = async (query, user) => {
         pipelines.push({$project: {_model: 0}});
     }
 
-    console.log(util.inspect(pipelines, false, 29, true));
+    //console.log(util.inspect(pipelines, false, 29, true));
 
     // 4. Exécuter la pipeline
     const ts = parseInt(timeout, 10)/2.0 || searchRequestTimeout;

--- a/src/modules/data.js
+++ b/src/modules/data.js
@@ -202,7 +202,6 @@ export const dataTypes = {
     },
     code: {
         validate: (value, field) => {
-            console.log(field,typeof(value));
             return value === null || (field.language === 'json' && typeof(value) === 'object') || (typeof value === 'string' && (field.maxlength === undefined || field.maxlength <= 0 || value.length <= field.maxlength));
         },
         filter: async (value, field) => {
@@ -2014,7 +2013,6 @@ export async function onInit(defaultEngine) {
                         .limit(maxModelsPerUser).toArray());
             res.json(models);
         } catch (error) {
-            console.log(error);
             logger.error(error);
             res.status(500).json({ success: false, error: error.message });
         }
@@ -2340,15 +2338,6 @@ export async function onInit(defaultEngine) {
             res.json({ success: true, value: resultValue, totalCount: totalCount });
 
         } catch (error) { // <--- CATCH PRINCIPAL
-            // --- Log de l'erreur BRUTE interceptée ---
-            console.log('--- CATCH PRINCIPAL - RAW ERROR OBJECT ---');
-            console.log('Type:', typeof error);
-            console.log('Instance of Error:', error instanceof Error);
-            console.log('Error Object:', error); // Affiche la structure brute
-            console.log('Error Message:', error?.message);
-            console.log('Error Stack:', error?.stack);
-            console.log('--- END CATCH PRINCIPAL ---');
-            // --- Fin Log ---
 
             // Tentative de log via le logger standard (qui peut encore échouer si l'erreur est vraiment étrange)
             try {
@@ -5923,10 +5912,7 @@ export async function installPack(packId, user, lang) {
 
 
 export const installAllPacks = async () => {
-
     const packs = await getAllPacks();
-
-    console.log(util.inspect(packs, false, 20, true));
     await packsCollection.deleteMany({ _user: { $exists : false }});
     await packsCollection.insertMany(packs);
 }

--- a/src/modules/data/data.js
+++ b/src/modules/data/data.js
@@ -1,4 +1,4 @@
-import {Logger} from "../gameObject.js";
+import {Logger} from "../../gameObject.js";
 import {BSON, ObjectId} from "mongodb";
 import * as util from 'node:util';
 import {promisify} from 'node:util';
@@ -9,9 +9,9 @@ import * as tar from "tar";
 import process from "node:process";
 import {randomColor} from "randomcolor";
 import cronstrue from 'cronstrue/i18n.js';
-import {setTimeoutMiddleware} from '../middlewares/timeout.js';
+import {setTimeoutMiddleware} from '../../middlewares/timeout.js';
 import {mkdir} from 'node:fs/promises';
-import {anonymizeText, getDefaultForType, getFieldValueHash, getUserId, isDemoUser, isLocalUser} from "../data.js";
+import {anonymizeText, getDefaultForType, getFieldValueHash, getUserId, isDemoUser, isLocalUser} from "../../data.js";
 import {
     allowedFields,
     dbName,
@@ -36,7 +36,7 @@ import {
     optionsSanitizer,
     searchRequestTimeout,
     storageSafetyMargin
-} from "../constants.js";
+} from "../../constants.js";
 import {
     getCollection,
     getCollectionForUser,
@@ -44,43 +44,43 @@ import {
     isObjectId,
     modelsCollection,
     packsCollection
-} from "./mongodb.js";
-import {dbUrl, MongoClient, MongoDatabase} from "../engine.js";
+} from "../mongodb.js";
+import {dbUrl, MongoClient, MongoDatabase} from "../../engine.js";
 import path from "node:path";
-import {getFileExtension, getObjectHash, getRandom, isGUID, isPlainObject, randomDate, sleep, uuidv4} from "../core.js";
-import {Event} from "../events.js";
+import {getFileExtension, getObjectHash, getRandom, isGUID, isPlainObject, randomDate, sleep, uuidv4} from "../../core.js";
+import {Event} from "../../events.js";
 import fs from "node:fs";
 import schedule from "node-schedule";
-import {middleware} from "../middlewares/middleware-mongodb.js";
-import i18n from "../i18n.js";
+import {middleware} from "../../middlewares/middleware-mongodb.js";
+import i18n from "../../i18n.js";
 import {
     executeSafeJavascript, processWorkflowRun,
     runScheduledJobWithDbLock,
     scheduleWorkflowTriggers,
     triggerWorkflows
-} from "./workflow.js";
+} from "../workflow.js";
 import NodeCache from "node-cache";
 import AWS from 'aws-sdk';
-import {openaiJobModel} from "../openai.jobs.js";
+import {openaiJobModel} from "../../openai.jobs.js";
 import checkDiskSpace from "check-disk-space";
 import {fileURLToPath} from 'url';
 import {Worker} from 'worker_threads';
-import {addFile, encryptFile, removeFile} from "./file.js";
-import {downloadFromS3, getS3Stream, getUserS3Config, listS3Backups, uploadToS3} from "./bucket.js";
+import {addFile, encryptFile, removeFile} from "../file.js";
+import {downloadFromS3, getS3Stream, getUserS3Config, listS3Backups, uploadToS3} from "../bucket.js";
 import {
     calculateTotalUserStorageUsage,
     generateLimiter,
     hasPermission,
     middlewareAuthenticator,
     userInitiator
-} from "./user.js";
-import {assistantGlobalLimiter} from "./assistant.js";
-import {getAllPacks} from "../packs.js";
-import {throttleMiddleware} from "../middlewares/throttle.js";
-import {Config} from "../config.js";
-import {profiles} from "../../client/src/constants.js";
-import {processFilterPlaceholders} from "../../client/src/filter.js";
-import {tutorialsConfig} from "../../client/src/tutorials.js";
+} from "../user.js";
+import {assistantGlobalLimiter} from "../assistant.js";
+import {getAllPacks} from "../../packs.js";
+import {throttleMiddleware} from "../../middlewares/throttle.js";
+import {Config} from "../../config.js";
+import {profiles} from "../../../client/src/constants.js";
+import {processFilterPlaceholders} from "../../../client/src/filter.js";
+import {tutorialsConfig} from "../../../client/src/tutorials.js";
 
 // Obtenir le chemin du répertoire courant de manière fiable avec ES Modules
 const __filename = fileURLToPath(import.meta.url);
@@ -535,7 +535,7 @@ export const getAPILang = (langs) => {
  */
 function runImportExportWorker(action, payload) {
     return new Promise((resolve, reject) => {
-        const workerPath = path.resolve(__dirname, '../workers/import-export-worker.js');
+        const workerPath = path.resolve(process.cwd(), './src/workers/import-export-worker.js');
         const worker = new Worker(workerPath);
 
         worker.postMessage({ action, payload });
@@ -570,7 +570,7 @@ function runImportExportWorker(action, payload) {
  */
 function runCryptoWorkerTask(action, payload) {
     return new Promise((resolve, reject) => {
-        const workerPath = path.resolve(__dirname, '../workers/crypto-worker.js');
+        const workerPath = path.resolve(process.cwd(), './src/workers/crypto-worker.js');
         const worker = new Worker(workerPath);
 
         worker.postMessage({ action, payload });

--- a/src/modules/data/index.js
+++ b/src/modules/data/index.js
@@ -1,0 +1,1 @@
+export * from './data.js';

--- a/src/modules/file.js
+++ b/src/modules/file.js
@@ -8,7 +8,7 @@ import {getFileExtension, isGUID, uuidv4} from "../core.js";
 import path from "node:path";
 import process from "node:process";
 import fs from "node:fs";
-import { checkServerCapacity} from "./data.js";
+import { checkServerCapacity} from "./data";
 import crypto from "node:crypto";
 import * as tar from "tar";
 import {promisify} from "node:util";

--- a/src/modules/user.js
+++ b/src/modules/user.js
@@ -3,7 +3,7 @@ import {MongoDatabase} from "../engine.js";
 import {getCollection, getCollectionForUser, getUserCollectionName} from "./mongodb.js";
 import {isLocalUser} from "../data.js";
 import {ObjectId} from "mongodb";
-import {getAPILang} from "./data.js";
+import {getAPILang} from "./data";
 import {Logger} from "../gameObject.js";
 import rateLimit from "express-rate-limit";
 

--- a/src/modules/workflow.js
+++ b/src/modules/workflow.js
@@ -1174,7 +1174,6 @@ export async function triggerWorkflows(triggerData, user, eventType)  {
 
 
                         console.debug(`[Workflow Trigger] Vérification dataFilter pour trigger ${trigger._id} avec filtre combiné:`, JSON.stringify(finalFilter));
-                        console.log({triggerData, finalFilter});
                         const match = await searchData({ model: triggerData._model, filter: finalFilter, limit: 1 }, user);
                         if (!match.count) {
                             console.debug(`[Workflow Trigger] Trigger ${trigger._id}: dataFilter non satisfait par la donnée ${dataId}. WorkflowRun non créé.`);
@@ -1358,7 +1357,6 @@ export async function processWorkflowRun(workflowRunId, user) {
                             if (!isObjectId(actionId)) continue;
                             const actionDef = await dbCollection.findOne({ _id: new ObjectId(actionId), _model: 'workflowAction' });
                             if (!actionDef) return await logError(`Action definition ${actionId} not found.`);
-                            console.log({actionDef});
                             const actionResult = await workflowModule.executeStepAction(actionDef, contextData, user, dbCollection);
 
                             if (actionResult.status === 'paused') {

--- a/src/modules/workflow.js
+++ b/src/modules/workflow.js
@@ -1,4 +1,3 @@
-// Exemple conceptuel dans la fonction de planification
 import {getCollection, getCollectionForUser, isObjectId} from "./mongodb.js";
 import schedule from "node-schedule";
 import {ObjectId} from "mongodb";
@@ -7,8 +6,8 @@ import crypto from "node:crypto";
 import ivm from 'isolated-vm';
 
 import {Logger} from "../gameObject.js";
-import {deleteData, insertData, patchData, searchData} from "./data.js";
-import {emailDefaultConfig, maxExecutionsByStep, maxWorkflowSteps, timeoutVM} from "../constants.js";
+import {deleteData, insertData, patchData, searchData} from "./data";
+import {emailDefaultConfig, maxExecutionsByStep, maxWorkflowSteps} from "../constants.js";
 import {ChatOpenAI} from "@langchain/openai";
 import {ChatGoogleGenerativeAI} from "@langchain/google-genai";
 import {ChatPromptTemplate} from "@langchain/core/prompts";
@@ -16,7 +15,6 @@ import i18n from "../../src/i18n.js";
 import {sendEmail} from "../email.js";
 
 import * as workflowModule from './workflow.js';
-import {isConditionMet} from "../filter.js";
 import util from "node:util";
 
 let logger = null;

--- a/src/packs.js
+++ b/src/packs.js
@@ -1,4 +1,4 @@
-import {getModels} from "./modules/data.js";
+import {getModels} from "./modules/data";
 
 
 /*

--- a/test/data.backup.integration.test.js
+++ b/test/data.backup.integration.test.js
@@ -10,18 +10,17 @@ import { vi } from 'vitest'
 import {
     createModel,
     insertData
-} from 'data-primals-engine/modules/data';
+} from '../src/index.js';
 
 import {
     modelsCollection as getAppModelsCollection,
     getCollectionForUser as getAppUserCollection, getCollectionForUser
-} from 'data-primals-engine/modules/mongodb';
+} from '../src/modules/mongodb.js';
 import process from "node:process";
 
-import { dumpUserData, loadFromDump } from 'data-primals-engine/modules/data';
+import { dumpUserData, loadFromDump } from '../src/index.js';
 import fs from "node:fs";
 import {initEngine} from "../src/setenv.js";
-import {getUserCollectionName} from "../src/modules/mongodb.js";
 
 vi.mock('data-primals-engine/engine', async(importOriginal) => {
     const mod = await importOriginal() // type is inferred

--- a/test/data.integration.test.js
+++ b/test/data.integration.test.js
@@ -7,19 +7,15 @@ import {
     editData,
     deleteData,
     searchData, installPack, deleteModels, createModel, patchData
-} from 'data-primals-engine/modules/data';
+} from '../src/index.js';
 
 import {
     modelsCollection as getAppModelsCollection,
     getCollection,
     getCollectionForUser as getAppUserCollection, getCollectionForUser
-} from 'data-primals-engine/modules/mongodb';
+} from '../src/modules/mongodb.js';
 import {getRandom} from "../src/core.js";
 import {generateUniqueName, initEngine} from "../src/setenv.js";
-import {processWorkflowRun} from "data-primals-engine/modules/workflow";
-import {sendEmail} from "../src/email.js";
-import {MongoDatabase} from "../src/engine.js";
-import {getUserCollectionName} from "../src/modules/mongodb.js";
 
 let testModelsColInstance;
 let testDatasColInstance;

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -1,7 +1,7 @@
 // events.test.js
 import { Event } from '../src/events.js';
 import {vitest} from "vitest";
-import {expect, describe, it, beforeEach, beforeAll, afterAll} from 'vitest';
+import {expect, describe, it, beforeEach} from 'vitest';
 
 describe('Event System', () => {
     beforeEach(() => {

--- a/test/file.test.js
+++ b/test/file.test.js
@@ -1,16 +1,13 @@
-// __tests__/file.integration.test.js
-import { expect, describe, it, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import { expect, describe, it, beforeEach, beforeAll, afterAll, vi } from 'vitest';
 import { Config } from '../src/config.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { ObjectId } from 'mongodb';
 import { initEngine, generateUniqueName } from "../src/setenv.js";
 import { addFile, removeFile, getFile, onInit } from "../src/modules/file.js";
 import {getCollection, getUserCollectionName} from "../src/modules/mongodb.js";
 import { Logger } from "../src/gameObject.js";
 import {maxPrivateFileSize} from "../src/constants.js";
-import {getCollectionForUser} from "data-primals-engine/modules/mongodb";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/test/import_export.integration.test.js
+++ b/test/import_export.integration.test.js
@@ -10,12 +10,11 @@ import {
 import {
     modelsCollection as getAppModelsCollection,
     getCollectionForUser as getAppUserCollection, getCollectionForUser
-} from 'data-primals-engine/modules/mongodb';
+} from '../src/modules/mongodb.js';
 import {sleep} from "data-primals-engine/core";
 import fs from "node:fs";
-import {getUniquePort, initEngine} from "../src/setenv.js";
+import {initEngine} from "../src/setenv.js";
 import {Config} from "../src/index.js";
-import {ObjectId} from "mongodb";
 
 // --- Données Mock ---
 const mockUser = {

--- a/test/model.integration.test.js
+++ b/test/model.integration.test.js
@@ -4,16 +4,14 @@ import {expect, describe, it, beforeEach, afterEach, beforeAll, afterAll, vi} fr
 import { Config } from '../src/config.js';
 
 import {
-    modelsCollection as getAppModelsCollection,
-    datasCollection, getCollection // Accès direct pour vérifications
+    getCollection // Accès direct pour vérifications
 } from 'data-primals-engine/modules/mongodb';
-import {generateUniqueName, getUniquePort, initEngine} from "../src/setenv.js";
+import {generateUniqueName, initEngine} from "../src/setenv.js";
 import {editModel} from "../src/modules/data.js";
-import {getCollectionForUser, getUserCollectionName} from "../src/modules/mongodb.js";
+import {getCollectionForUser} from "../src/modules/mongodb.js";
 
 let testModelsColInstance;
 let testModelId;
-let lastUser;
 // Cette fonction va remplacer la logique de votre beforeEach pour la création de contexte
 async function setupTestContext() {
 
@@ -24,7 +22,7 @@ async function setupTestContext() {
     // Créer un utilisateur unique pour ce test
     const currentTestUser = {
         username: generateUniqueName('testuserModelIntegration'),
-        userPlan: 'premium',
+        userPlan: 'free',
         email: generateUniqueName('test') + '@example.com'
     };
 
@@ -125,7 +123,7 @@ describe('CRUD on model definitions and integrity tests', () => {
 
     describe('editModel unit tests', () => {
 
-        it.skip('should create and drop index when field.index is toggled (premium user)', async () => {
+        it('should create and drop index when field.index is toggled (premium user)', async () => {
             // --- SETUP ---
             const { coll, currentTestUser, comprehensiveTestModelDefinition } = await setupTestContext();
             const fieldToIndex = 'stringUnique'; // Utiliser un champ qui existe vraiment dans le modèle

--- a/test/model.integration.test.js
+++ b/test/model.integration.test.js
@@ -1,13 +1,13 @@
 // __tests__/data.integration.test.js
 import { ObjectId } from 'mongodb';
-import {expect, describe, it, beforeEach, afterEach, beforeAll, afterAll, vi} from 'vitest';
+import {expect, describe, it, beforeAll} from 'vitest';
 import { Config } from '../src/config.js';
 
 import {
     getCollection // Accès direct pour vérifications
-} from 'data-primals-engine/modules/mongodb';
+} from '../src/modules/mongodb.js';
 import {generateUniqueName, initEngine} from "../src/setenv.js";
-import {editModel} from "../src/modules/data.js";
+import {editModel} from "../src/index.js";
 import {getCollectionForUser} from "../src/modules/mongodb.js";
 
 let testModelsColInstance;

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -5,7 +5,7 @@ import {generateUniqueName} from "../src/setenv.js";
 import {
     getCollectionForUser as getAppUserCollection,
     modelsCollection as getAppModelsCollection
-} from "data-primals-engine/modules/mongodb";
+} from "../src/modules/mongodb.js";
 import {Config} from "../src/index.js";
 let permRead, permWrite, permDelete, permManage;
 let roleEditor;

--- a/test/workflow.integration.test.js
+++ b/test/workflow.integration.test.js
@@ -1,20 +1,16 @@
-// __tests__/workflow.integration.test.js
 import { expect, describe, it, beforeEach,afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { Config } from "data-primals-engine/config";
 
-import {insertData, editData, deleteData, patchData} from 'data-primals-engine/modules/data';
-import { modelsCollection as getAppModelsCollection, getCollectionForUser } from 'data-primals-engine/modules/mongodb';
-import * as workflowModule from 'data-primals-engine/modules/workflow';
-import {getUniquePort, initEngine} from "../src/setenv.js";
-import process from "process";
-import {getUserCollectionName} from "../src/modules/mongodb.js";
-
+import {insertData, editData, deleteData, patchData} from '../src/index.js';
+import { modelsCollection as getAppModelsCollection, getCollectionForUser } from '../src/modules/mongodb.js';
+import * as workflowModule from '../src/modules/workflow.js';
+import {initEngine} from "../src/setenv.js";
 
 beforeAll(async () =>{
     Config.Set("modules", ["mongodb", "data", "file", "bucket", "workflow","user", "assistant"]);
     await initEngine();
 })
-vi.mock('data-primals-engine/modules/workflow', { spy: true })
+vi.mock('../src/modules/workflow.js', { spy: true })
 // --- Données Mock pour les tests ---
 const mockUser = {
     username: 'testuserWorkflow',

--- a/test/workflow.robustness.test.js
+++ b/test/workflow.robustness.test.js
@@ -1,15 +1,14 @@
 import { ObjectId } from 'mongodb';
 import {expect, describe, it, beforeEach, beforeAll, vi, afterAll, afterEach} from 'vitest';
 import { Config } from "data-primals-engine/config";
-// --- Importations des modules de l'application ---
-import { insertData, editData } from 'data-primals-engine/modules/data';
-import { modelsCollection as getAppModelsCollection, getCollectionForUser, getCollection } from 'data-primals-engine/modules/mongodb';
-import * as workflowModule from 'data-primals-engine/modules/workflow';
+
+import { insertData, editData } from '../src/index.js';
+import { modelsCollection as getAppModelsCollection, getCollectionForUser, getCollection } from '../src/modules/mongodb.js';
+import * as workflowModule from '../src/modules/workflow.js';
 import {initEngine} from "../src/setenv.js";
 import {maxExecutionsByStep} from "../src/constants.js";
-import {getUserCollectionName} from "../src/modules/mongodb.js";
 
-vi.mock('data-primals-engine/modules/workflow', { spy: true })
+vi.mock('../src/modules/workflow.js', { spy: true })
 
 const mockUser = {
     username: 'robustnessUser',

--- a/test/workflow.robustness.test.js
+++ b/test/workflow.robustness.test.js
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb';
-import {expect, describe, it, beforeEach, beforeAll, vi, afterAll} from 'vitest';
+import {expect, describe, it, beforeEach, beforeAll, vi, afterAll, afterEach} from 'vitest';
 import { Config } from "data-primals-engine/config";
 // --- Importations des modules de l'application ---
 import { insertData, editData } from 'data-primals-engine/modules/data';
@@ -45,8 +45,15 @@ beforeEach(async () => {
     if( mods.length === 0){
         await testModelsColInstance.insertMany([targetDataModel, ...workflowMetaModels]);
     }
-});
+    // tell vitest we use mocked time
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+})
 
+afterEach(() => {
+    vi.runOnlyPendingTimers();
+    // restoring date after each test run
+    vi.useRealTimers()
+})
 afterAll(async () => {
     const coll = await getCollectionForUser(mockUser);
     await coll.drop();


### PR DESCRIPTION
## Directory-First Approach: 
The system now resolves a module identifier to a directory path.
+ It first checks if the identifier is a direct path to an existing directory (e.g., './custom-modules/users').
+ If not, it assumes it's a module name and looks for it within the default ./src/modules directory.

### Flexible Entry Points: 
Once a module's directory is located, the loader searches for a valid entry point file

### Robust Path Handling: 
It correctly handles both simple module names (like 'data') and relative paths by using path.basename() to extract the module name for entry point resolution.

### Clean Module List: 
Modules that fail to load for any reason (not found, error during import) are now filtered out. The final engine._modules array will only contain successfully loaded modules, preventing undefined entries and potential downstream errors.